### PR TITLE
fix: Fixed the tf provider version to >= 1.8.0

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     equinix = {
       source  = "equinix/equinix"
-      version = ">= 1.13.0"
+      version = ">= 1.8.0"
     }
   }
 }


### PR DESCRIPTION
This PR addresses the following:
- Fixed the terraform provider version to >= 1.8.0